### PR TITLE
added http 1.1 version and settings for WebSocket proxy

### DIFF
--- a/roles/egress-proxy/templates/nginx.conf
+++ b/roles/egress-proxy/templates/nginx.conf
@@ -8,6 +8,12 @@ events {
 
 
 http {
+    # WebSocket proxying http://nginx.org/en/docs/http/websocket.html
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        "" "";
+    }
+
     log_format general	'$remote_addr $host [$time_iso8601] $request_time '
                     '"$request" $status $body_bytes_sent '
                     '"$http_referer" "$http_user_agent" $remote_user';
@@ -20,6 +26,8 @@ http {
     proxy_temp_path tmp/proxy_temp_path;
     scgi_temp_path tmp/scgi_temp;
     uwsgi_temp_path tmp/uwsgi_temp;
+    proxy_http_version 1.1;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     client_body_timeout  3600s;
 


### PR DESCRIPTION
Proxy can't restrict HTTP 1.0 from bypassing the `server` section so HTTP 1.1 must be enforced